### PR TITLE
Add GetOrg query

### DIFF
--- a/graphql/GetOrg.graphql
+++ b/graphql/GetOrg.graphql
@@ -1,0 +1,6 @@
+query GetOrg ($login: String!) {
+  organization(login: $login){
+    name,
+    login,
+  }
+}


### PR DESCRIPTION
## TL;DR

- 指定IDの組織情報を返すQueryを書いてみた
- 下記みたいな感じのことをやってる

![image](https://user-images.githubusercontent.com/7234418/59114274-caefa400-8981-11e9-9b99-1df265477b73.png)


## Check list

- [x] 下記が `src/generate/graphql.tsx` に吐かれてること

```typescript
export const GetOrgDocument = gql`
  query GetOrg($login: String!) {
    organization(login: $login) {
      name
      login
    }
  }
`;

export function useGetOrgQuery(
  baseOptions?: ReactApolloHooks.QueryHookOptions<GetOrgQueryVariables>
) {
  return ReactApolloHooks.useQuery<GetOrgQuery, GetOrgQueryVariables>(
    GetOrgDocument,
    baseOptions
  );
}
```