### PR TITLE
Add GetRepos query

### DIFF
--- a/graphql/GetRepos.graphql
+++ b/graphql/GetRepos.graphql
@@ -1,0 +1,20 @@
+query GetRepos($owner: String!) {
+  user(login: $owner) {
+    repositories(last: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      totalCount
+      pageInfo {
+        hasNextPage,
+        hasPreviousPage
+      }
+      edges {
+        cursor,
+        node {
+          name,
+          url,
+          createdAt
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
TL;DR

指定したユーザー(owner) のリポジトリー一覧を返す Query を書いてみた

<img width="988" alt="スクリーンショット 2019-07-02 22 38 40" src="https://user-images.githubusercontent.com/56591/60517098-0596f300-9d1a-11e9-89fd-ce0989913880.png">

[ ] 下記が src/generate/graphql.tsx に吐かれてること

```
export const GetReposDocument = gql`
  query GetRepos($owner: String!) {
    user(login: $owner) {
      repositories(last: 100, orderBy: { field: UPDATED_AT, direction: DESC }) {
        totalCount
        pageInfo {
          hasNextPage
          hasPreviousPage
        }
        edges {
          cursor
          node {
            name
            url
            createdAt
          }
        }
      }
    }
  }
`;

export function useGetReposQuery(
  baseOptions?: ReactApolloHooks.QueryHookOptions<GetReposQueryVariables>
) {
  return ReactApolloHooks.useQuery<GetReposQuery, GetReposQueryVariables>(
    GetReposDocument,
    baseOptions
  );
}
```